### PR TITLE
Escaping '/' Characters in Html File Names

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -103,7 +103,8 @@ const injectScriptInHtmlFiles = async () => {
   const paths = await globby(['public/**/*.html']);
   const urls = paths.map(p => {
     return p.replace("public/", "")
-            .replace("/index.html", "");
+            .replace("/index.html", "")
+			.replace("/", "\\/");
   });
 
   const scriptContents = `var re=/\\/(${urls.join("|")})?(\\/[^\/]*)?$/g;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -104,7 +104,7 @@ const injectScriptInHtmlFiles = async () => {
   const urls = paths.map(p => {
     return p.replace("public/", "")
             .replace("/index.html", "")
-			.replace("/", "\\/");
+            .replace("/", "\\/");
   });
 
   const scriptContents = `var re=/\\/(${urls.join("|")})?(\\/[^\/]*)?$/g;


### PR DESCRIPTION
This allows us to generate valid regex for nested html files. e.g. 'my/file.html'.